### PR TITLE
Merge analytics from all language subdomains

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -66,7 +66,7 @@
         font-style: italic;
       }
     </style>
-    <script async defer type="text/javascript" src="https://plausible.io/js/plausible.js"></script>
+    <script async defer type="text/javascript" data-domain="communitycodeofconduct.com" src="https://plausible.io/js/plausible.js"></script>
   </head>
   <body>
     {{content}}


### PR DESCRIPTION
This site runs on different subdomains for different languages (`de.communitycodeofconduct.com`, `it.communitycodeofconduct.com`, etc).

This PR uses a new capability in Plausible to override the domain for which traffic is measured. This means that all traffic will show up on the `communitycodeofconduct.com` dashboard, even if the visitor was actually on a subdomain.